### PR TITLE
feat: Add SonarQube analysis to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,45 @@ jobs:
 
 #    - name: Build uberjar (optional)
 #      run: nix-shell --run "cd rwclj && clj -M:uberjar"
+
+  sonarqube:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin' # Optional 'temurin' or 'zulu'
+      - name: Cache SonarQube packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }} # Replace with your SonarQube server URL
+        with:
+          args: >
+            -Dsonar.projectKey=your_project_key # Replace with your project key
+            -Dsonar.organization=your_organization_key # Replace with your organization key
+            -Dsonar.sources=rwclj/src
+            -Dsonar.tests=rwclj/test
+            -Dsonar.junit.reportPaths=rwclj/target/junit.xml
+            -Dsonar.java.binaries=rwclj/target/classes # Adjust if necessary
+            -Dsonar.clojure.file.suffixes=.clj,.cljs,.cljc # Assuming a Clojure plugin might use this
+            -Dsonar.sourceEncoding=UTF-8

--- a/rwclj/sonar-project.properties
+++ b/rwclj/sonar-project.properties
@@ -1,0 +1,30 @@
+# Root project information
+sonar.projectKey=your_project_key # Replace with your project key (must be unique in SonarQube)
+sonar.projectName=rwclj # Replace with a human-readable name for your project
+sonar.projectVersion=0.1.0-SNAPSHOT # Replace with your project's version
+
+# Path to source code
+sonar.sources=src
+
+# Path to test code
+sonar.tests=test
+
+# Path to JUnit XML reports
+sonar.junit.reportPaths=target/junit.xml
+
+# Encoding of the source code
+sonar.sourceEncoding=UTF-8
+
+# Optional: Specify language if not auto-detected (though SonarQube usually does this well)
+# sonar.language=clj
+
+# Optional: If using a specific Clojure plugin, its properties would go here
+# For example, if there's a community plugin like sonar-clojure:
+# sonar.clojure.file.suffixes=.clj,.cljs,.cljc
+# sonar.clojure.coverage.reportPaths=target/coverage/clover.xml (if you generate Clover XML)
+
+# Location of compiled .class files (may or may not be needed depending on analyzers)
+# SonarQube often requires this for some of its internal workings, even for non-Java projects.
+# If your Clojure build doesn't produce .class files in a standard location,
+# or if the Clojure analyzer doesn't need them, this can be removed or adjusted.
+sonar.java.binaries=target/classes


### PR DESCRIPTION
- Modified GitHub Actions workflow to include a SonarQube scan job.
- Added sonar-project.properties file for SonarQube configuration.
- The SonarQube job runs on pushes to main and requires SONAR_TOKEN and SONAR_HOST_URL secrets.
- User needs to configure project key, organization key, and potentially a Clojure plugin in SonarQube.