### PR TITLE
Fix: Unskip and allow parse-vcard-line-test to pass

### DIFF
--- a/rwclj/project.clj
+++ b/rwclj/project.clj
@@ -3,7 +3,14 @@
   :url "https://github.com/bmordue/redweed"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.11.1"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/tools.logging "1.3.0"]
+                 [org.apache.jena/jena-tdb2 "5.0.0"]
+                 [clj-http "3.13.0"]
+                 [metosin/jsonista "0.3.13"]
+                 [ring/ring-jetty-adapter "1.14.2"]
+                 [ring/ring-json "0.5.1"]
+                 [compojure "1.7.1"]]
   :main ^:skip-aot rwclj.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all

--- a/rwclj/run_tests.sh
+++ b/rwclj/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+/usr/local/bin/lein test

--- a/rwclj/test/rwclj/vcard_test.clj
+++ b/rwclj/test/rwclj/vcard_test.clj
@@ -16,7 +16,7 @@
           (.getString object)
           (.toString object)))))) ; Handle non-literals too, though mostly expecting literals here
 
-(deftest ^:kaocha/skip parse-vcard-line-test
+(deftest parse-vcard-line-test
   (testing "Parsing individual vCard lines"
     (is (= ["FN" "John Doe"] (vcard/parse-vcard-line "FN:John Doe")))
     (is (= ["N" "Doe;John;;;"] (vcard/parse-vcard-line "N:Doe;John;;;")))


### PR DESCRIPTION
Unskipped rwclj.vcard-test/parse-vcard-line-test and added necessary dependencies to project.clj to allow it to pass.

The following dependencies were added:
- org.clojure/tools.logging "1.3.0"
- org.apache.jena/jena-tdb2 "5.0.0"
- clj-http "3.13.0"
- metosin/jsonista "0.3.13"
- ring/ring-jetty-adapter "1.14.2"
- ring/ring-json "0.5.1"
- compojure "1.7.1"

Other tests in the project continue to fail, but this change addresses the specific request to get at least one vcard test passing.