### PR TITLE
feat: Add API to import reviews

### DIFF
--- a/API.md
+++ b/API.md
@@ -17,6 +17,36 @@ This document provides a detailed description of the Redweed API endpoints.
         }
         ```
 
+## Reviews
+
+### POST /api/review/import
+
+*   **Description:** Imports a review.
+*   **Consumes:** `application/json`
+*   **Parameters:**
+    *   `body`: The review data as a JSON object.
+        ```json
+        {
+          "rating": 5,
+          "text": "This is a great product!"
+        }
+        ```
+*   **Responses:**
+    *   `201 Created`: Review imported successfully.
+        ```json
+        {
+          "status": "success",
+          "review-uri": "...",
+          "message": "Review imported successfully"
+        }
+        ```
+    *   `400 Bad Request`: Invalid review data.
+        ```json
+        {
+          "error": "Invalid review format"
+        }
+        ```
+
 ## vCard
 
 ### POST /api/vcard/import

--- a/rwclj/src/rwclj/db.clj
+++ b/rwclj/src/rwclj/db.clj
@@ -43,3 +43,19 @@
     (.add target-model model)
     (log/info "Successfully stored RDF model")))
 
+(defn execute-sparql-update
+  ([update-string]
+   (with-open [dataset (get-dataset)]
+     (.begin dataset)
+     (try
+       (execute-sparql-update dataset update-string)
+       (.commit dataset)
+       (finally
+         (.end dataset)))))
+  ([dataset update-string]
+   (try
+     (let [update (UpdateFactory/create update-string)]
+       (with-open [qexec (UpdateExecutionFactory/create update dataset)]
+         (.execute qexec)))
+     (catch Exception e
+       (log/error e "Error executing SPARQL update")))))

--- a/rwclj/src/rwclj/review.clj
+++ b/rwclj/src/rwclj/review.clj
@@ -1,0 +1,37 @@
+(ns rwclj.review
+  (:require [clojure.tools.logging :as log]
+            [rwclj.db :as db]
+            [clojure.string :as str])
+  (:import [org.apache.jena.update UpdateFactory UpdateExecutionFactory]
+           [org.apache.jena.query QueryFactory]))
+
+(defn build-review-insert-query [review-uri rating text]
+  (str "
+  PREFIX schema: <http://schema.org/>
+  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+  INSERT DATA {
+    <" review-uri "> a schema:Review .
+    " (when rating (str "<" review-uri "> schema:ratingValue " rating " .")) "
+    " (when text (str "<" review-uri "> schema:reviewBody \"" text "\" .")) "
+  }"))
+
+(defn import-review [review-data]
+  (log/info "Importing review:" review-data)
+  (let [review-uri (str "urn:uuid:" (java.util.UUID/randomUUID))
+        query (build-review-insert-query review-uri (:rating review-data) (:text review-data))]
+    (db/execute-sparql-update query)
+    {:status "success"
+     :review-uri review-uri
+     :message "Review imported successfully"}))
+
+(defn import-review-handler [request]
+  (let [review-data (:body request)]
+    (try
+      (let [result (import-review review-data)]
+        {:status 201
+         :body result})
+      (catch Exception e
+        (log/error e "Error importing review")
+        {:status 400
+         :body {:error "Invalid review format"}}))))

--- a/rwclj/src/rwclj/server.clj
+++ b/rwclj/src/rwclj/server.clj
@@ -10,6 +10,7 @@
             [clojure.string :as str]
             [rwclj.vcard :as vcard]
             [rwclj.db :as db]
+            [rwclj.review :as review]
 
             ;; [ring.swagger.swagger-ui :as swagger-ui]
             ;; [ring.swagger.core :as swagger]
@@ -141,6 +142,14 @@
      :responses {200 {:body {:message string? :file-uri string?}}
                  500 {:body {:error string?}}}
      :handler (fn [request] (photo/process-photo-upload request))})
+
+  (POST "/api/review/import" request
+    {:summary "Import a review"
+     :consumes ["application/json"]
+     :parameters {:body {:review map?}}
+     :responses {201 {:body {:message string? :review-uri string?}}
+                 400 {:body {:error string?}}}
+     :handler (fn [request] (review/import-review-handler request))})
 
   ;; API documentation
   ;; (swagger-ui/create-swagger-ui-handler {:path "/api-docs"})

--- a/rwclj/test/rwclj/review_test.clj
+++ b/rwclj/test/rwclj/review_test.clj
@@ -1,0 +1,11 @@
+(ns rwclj.review-test
+  (:require [clojure.test :refer :all]
+            [rwclj.review :as review]
+            [rwclj.db :as db]))
+
+(deftest import-review-test
+  (testing "Test importing a review"
+    (let [review-data {:rating 5 :text "Great product!"}
+          result (review/import-review review-data)]
+      (is (= "success" (:status result)))
+      (is (not (nil? (:review-uri result)))))))


### PR DESCRIPTION
This commit adds a new API endpoint to import reviews. It includes a new `rwclj.review` namespace with logic to handle review import, a new route in `rwclj.server`, and updates to `API.md`.

Note: The tests for this feature have not been run due to issues with the test environment.