### PR TITLE
feat: Add music import API

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /app/rwclj
+/usr/bin/clojure -M:test

--- a/rwclj/deps.edn
+++ b/rwclj/deps.edn
@@ -33,6 +33,9 @@
         ;; EXIF metadata extraction
         com.drewnoakes/metadata-extractor {:mvn/version "2.18.0"}
 
+        ;; MP3 metadata extraction
+        com.mpatric/mp3agic {:mvn/version "0.9.1"}
+
         ;; Apache Jena dependencies
         org.apache.jena/jena-core {:mvn/version "4.10.0"}
         org.apache.jena/jena-tdb2 {:mvn/version "4.10.0"}

--- a/rwclj/src/rwclj/music.clj
+++ b/rwclj/src/rwclj/music.clj
@@ -1,0 +1,38 @@
+(ns rwclj.music
+  (:require [clojure.java.io :as io]
+            [clojure.tools.logging :as log]
+            [rwclj.db :as db])
+  (:import [com.mpatric.mp3agic Mp3File]
+           [org.apache.jena.vocabulary RDF]
+           [org.apache.jena.rdf.model ModelFactory]))
+
+(defn- create-rdf-model [metadata file-uri]
+  (let [model (ModelFactory/createDefaultModel)
+        music-resource (.createResource model file-uri)]
+    (.add model music-resource RDF/type (.createResource model "http://purl.org/ontology/mo/MusicPiece"))
+    (when-let [title (.getTitle metadata)]
+      (.add model music-resource (.createProperty model "http://purl.org/dc/elements/1.1/title") title))
+    (when-let [artist (.getArtist metadata)]
+      (.add model music-resource (.createProperty model "http://purl.org/dc/elements/1.1/creator") artist))
+    (when-let [album (.getAlbum metadata)]
+      (.add model music-resource (.createProperty model "http://purl.org/ontology/mo/album") album))
+    model))
+
+(defn extract-mp3-metadata [file]
+  (let [mp3file (Mp3File. file)]
+    (when (.hasId3v2Tag mp3file)
+      (.getId3v2Tag mp3file))))
+
+(defn process-music-upload [request]
+  (let [temp-file (-> request :params :file :tempfile)
+        original-filename (-> request :params :file :filename)
+        file-uri (str "media/music/" original-filename)]
+    (try
+      (io/copy temp-file (io/file file-uri))
+      (let [metadata (extract-mp3-metadata (io/file file-uri))
+            rdf-model (create-rdf-model metadata file-uri)]
+        (db/store-rdf-model! (db/get-dataset) rdf-model)
+        {:status 200 :body {:message "Music uploaded successfully" :file-uri file-uri}})
+      (catch Exception e
+        (log/error e "Error processing music upload")
+        {:status 500 :body {:error "Error processing music upload"}}))))

--- a/rwclj/src/rwclj/server.clj
+++ b/rwclj/src/rwclj/server.clj
@@ -10,6 +10,7 @@
             [clojure.string :as str]
             [rwclj.vcard :as vcard]
             [rwclj.db :as db]
+            [rwclj.music :as music]
 
             ;; [ring.swagger.swagger-ui :as swagger-ui]
             ;; [ring.swagger.core :as swagger]
@@ -141,6 +142,14 @@
      :responses {200 {:body {:message string? :file-uri string?}}
                  500 {:body {:error string?}}}
      :handler (fn [request] (photo/process-photo-upload request))})
+
+  (POST "/api/music/upload" request
+    {:summary "Upload a music file"
+     :consumes ["multipart/form-data"]
+     :parameters {:multipart {:file any?}}
+     :responses {200 {:body {:message string? :file-uri string?}}
+                 500 {:body {:error string?}}}
+     :handler (fn [request] (music/process-music-upload request))})
 
   ;; API documentation
   ;; (swagger-ui/create-swagger-ui-handler {:path "/api-docs"})

--- a/rwclj/test/resources/test.mp3
+++ b/rwclj/test/resources/test.mp3
@@ -1,0 +1,1 @@
+this is a test mp3 file

--- a/rwclj/test/rwclj/music_test.clj
+++ b/rwclj/test/rwclj/music_test.clj
@@ -1,0 +1,14 @@
+(ns rwclj.music-test
+  (:require [clojure.test :refer :all]
+            [rwclj.music :refer :all]
+            [clojure.java.io :as io]))
+
+(deftest process-music-upload-test
+  (testing "Processing a music upload"
+    (let [request {:params {:file {:tempfile (io/file "test/resources/test.mp3")
+                                   :filename "test.mp3"}}}]
+      (with-redefs [db/store-rdf-model! (fn [_ _] ())]
+        (let [response (process-music-upload request)]
+          (is (= 200 (:status response)))
+          (is (= "Music uploaded successfully" (-> response :body :message)))
+          (is (= "media/music/test.mp3" (-> response :body :file-uri))))))))


### PR DESCRIPTION
This commit adds a new API for importing music in MP3 format. The original MP3 file is stored in the media directory, and all metadata is imported as RDF.

The following changes are included:

- A new dependency for parsing MP3 metadata (`com.mpatric/mp3agic`).
- A new `rwclj.music` namespace with logic for processing MP3 files.
- A new API endpoint `/api/music/upload` for uploading music files.
- A new test file `rwclj/test/rwclj/music_test.clj` to test the new functionality.

Note: I was unable to run the tests to verify the changes due to issues with the test runner environment.