### PR TITLE
Fix an XXE vulnerability in KmlParser

### DIFF
--- a/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
+++ b/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
@@ -20,10 +20,30 @@ public class KmlParser {
         List<Map<String, String>> placemarks = new ArrayList<>();
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            try {
+                factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
+                // Log or handle the exception as needed
+                System.err.println("Warning: FEATURE_SECURE_PROCESSING not supported: " + e.getMessage());
+            }
+            try {
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
+                // Log or handle the exception as needed
+                System.err.println("Warning: disallow-doctype-decl not supported: " + e.getMessage());
+            }
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
+                // Log or handle the exception as needed
+                System.err.println("Warning: external-general-entities not supported: " + e.getMessage());
+            }
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
+                // Log or handle the exception as needed
+                System.err.println("Warning: external-parameter-entities not supported: " + e.getMessage());
+            }
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(kmlString)));
             NodeList placemarkNodes = doc.getElementsByTagName("Placemark");

--- a/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
+++ b/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
@@ -21,6 +21,9 @@ public class KmlParser {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(kmlString)));
             NodeList placemarkNodes = doc.getElementsByTagName("Placemark");

--- a/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
+++ b/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
@@ -19,16 +19,26 @@ import java.util.Map;
 
 public class KmlParser {
 
+    private static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+    private static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+    private static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+
+    private KmlParser() {
+        // hide public constructor
+    }
+
     public static List<Map<String, String>> parse(String kmlString) {
         List<Map<String, String>> placemarks = new ArrayList<>();
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-factory.setXIncludeAware(false);
-factory.setExpandEntityReferences(false);
+            factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+            factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+            factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+            factory.setFeature(LOAD_EXTERNAL_DTD, false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(kmlString)));
 

--- a/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
+++ b/jweed/src/main/java/me/bmordue/redweed/util/KmlParser.java
@@ -23,30 +23,12 @@ public class KmlParser {
         List<Map<String, String>> placemarks = new ArrayList<>();
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            try {
-                factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
-                // Log or handle the exception as needed
-                System.err.println("Warning: FEATURE_SECURE_PROCESSING not supported: " + e.getMessage());
-            }
-            try {
-                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
-                // Log or handle the exception as needed
-                System.err.println("Warning: disallow-doctype-decl not supported: " + e.getMessage());
-            }
-            try {
-                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
-                // Log or handle the exception as needed
-                System.err.println("Warning: external-general-entities not supported: " + e.getMessage());
-            }
-            try {
-                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            } catch (javax.xml.parsers.ParserConfigurationException | UnsupportedOperationException e) {
-                // Log or handle the exception as needed
-                System.err.println("Warning: external-parameter-entities not supported: " + e.getMessage());
-            }
+factory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+factory.setXIncludeAware(false);
+factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(kmlString)));
 


### PR DESCRIPTION
Disable DTDs and external entities in the KML parser to prevent XXE attacks.

Fixes https://github.com/bmordue/redweed/security/code-scanning/1