### PR TITLE
feat: Import vCards from CalDAV server

### DIFF
--- a/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportController.java
+++ b/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportController.java
@@ -17,6 +17,15 @@ public class VCardImportController {
 
     @Post("/vcard")
     public HttpResponse<?> importVCards(@Body VCardImportRequest request) {
+        if (request.addressbookUrl() == null || request.addressbookUrl().isEmpty()) {
+            return HttpResponse.badRequest("addressbookUrl must not be null or empty");
+        }
+        if (request.username() == null || request.username().isEmpty()) {
+            return HttpResponse.badRequest("username must not be null or empty");
+        }
+        if (request.password() == null || request.password().isEmpty()) {
+            return HttpResponse.badRequest("password must not be null or empty");
+        }
         vCardImportService.importVCards(request.addressbookUrl(), request.username(), request.password());
         return HttpResponse.ok();
     }

--- a/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportController.java
+++ b/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportController.java
@@ -17,7 +17,7 @@ public class VCardImportController {
 
     @Post("/vcard")
     public HttpResponse<?> importVCards(@Body VCardImportRequest request) {
-        if (request.addressbookUrl() == null || request.addressbookUrl().isEmpty()) {
+        if (request.addressbookUrl() == null) {
             return HttpResponse.badRequest("addressbookUrl must not be null or empty");
         }
         if (request.username() == null || request.username().isEmpty()) {

--- a/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportController.java
+++ b/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportController.java
@@ -1,0 +1,23 @@
+package me.bmordue.redweed.controller;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import me.bmordue.redweed.service.VCardImportService;
+
+@Controller("/import")
+public class VCardImportController {
+
+    private final VCardImportService vCardImportService;
+
+    public VCardImportController(VCardImportService vCardImportService) {
+        this.vCardImportService = vCardImportService;
+    }
+
+    @Post("/vcard")
+    public HttpResponse<?> importVCards(@Body VCardImportRequest request) {
+        vCardImportService.importVCards(request.addressbookUrl(), request.username(), request.password());
+        return HttpResponse.ok();
+    }
+}

--- a/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportRequest.java
+++ b/jweed/src/main/java/me/bmordue/redweed/controller/VCardImportRequest.java
@@ -1,0 +1,9 @@
+package me.bmordue.redweed.controller;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.net.URI;
+
+@Introspected
+public record VCardImportRequest(URI addressbookUrl, String username, String password) {
+}

--- a/jweed/src/main/java/me/bmordue/redweed/model/Addressbook.java
+++ b/jweed/src/main/java/me/bmordue/redweed/model/Addressbook.java
@@ -1,0 +1,6 @@
+package me.bmordue.redweed.model;
+
+import java.net.URI;
+
+public record Addressbook(URI href, String displayName) {
+}

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -1,0 +1,165 @@
+package me.bmordue.redweed.service;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import jakarta.inject.Singleton;
+import me.bmordue.redweed.model.Addressbook;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+@Singleton
+public class CaldavService {
+
+    private final HttpClient httpClient;
+
+    public CaldavService(@Client HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public String findAddressbookHomeSetUrl(URI principalUrl, String username, String password) {
+        String requestBody = """
+                <d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
+                  <d:prop>
+                     <c:addressbook-home-set />
+                  </d:prop>
+                </d:propfind>
+                """;
+
+        HttpRequest<?> request = HttpRequest.create("PROPFIND", principalUrl.toString())
+                .header("Depth", "0")
+                .header("Content-Type", "application/xml")
+                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
+                .body(requestBody);
+
+        HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
+
+        if (response.getStatus().getCode() >= 200 && response.getStatus().getCode() < 300) {
+            return extractAddressbookHomeSetUrl(response.body());
+        } else {
+            throw new RuntimeException("Failed to find addressbook home set: " + response.getStatus());
+        }
+    }
+
+    public List<Addressbook> findAddressbooks(URI addressbookHomeSetUrl, String username, String password) {
+        String requestBody = """
+                <d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
+                  <d:prop>
+                     <d:resourcetype />
+                     <d:displayname />
+                  </d:prop>
+                </d:propfind>
+                """;
+
+        HttpRequest<?> request = HttpRequest.create("PROPFIND", addressbookHomeSetUrl.toString())
+                .header("Depth", "1")
+                .header("Content-Type", "application/xml")
+                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
+                .body(requestBody);
+
+        HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
+
+        if (response.getStatus().getCode() >= 200 && response.getStatus().getCode() < 300) {
+            return extractAddressbooks(response.body());
+        } else {
+            throw new RuntimeException("Failed to find addressbooks: " + response.getStatus());
+        }
+    }
+
+    public List<String> getVCards(URI addressbookUrl, String username, String password) {
+        String requestBody = """
+                <c:addressbook-multiget xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
+                  <d:prop>
+                    <d:getetag />
+                    <c:address-data />
+                  </d:prop>
+                </c:addressbook-multiget>
+                """;
+
+        HttpRequest<?> request = HttpRequest.create("REPORT", addressbookUrl.toString())
+                .header("Content-Type", "application/xml")
+                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
+                .body(requestBody);
+
+        HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
+
+        if (response.getStatus().getCode() >= 200 && response.getStatus().getCode() < 300) {
+            return extractVCards(response.body());
+        } else {
+            throw new RuntimeException("Failed to get vCards: " + response.getStatus());
+        }
+    }
+
+    private String extractAddressbookHomeSetUrl(String xmlResponse) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new InputSource(new StringReader(xmlResponse)));
+            return doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "addressbook-home-set")
+                    .item(0)
+                    .getChildNodes()
+                    .item(0)
+                    .getTextContent();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse addressbook home set URL from response", e);
+        }
+    }
+
+    private List<Addressbook> extractAddressbooks(String xmlResponse) {
+        List<Addressbook> addressbooks = new ArrayList<>();
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new InputSource(new StringReader(xmlResponse)));
+            NodeList responseNodes = doc.getElementsByTagNameNS("DAV:", "response");
+            for (int i = 0; i < responseNodes.getLength(); i++) {
+                Element responseElement = (Element) responseNodes.item(i);
+                NodeList resourceTypeNodes = responseElement.getElementsByTagNameNS("DAV:", "resourcetype");
+                boolean isAddressbook = false;
+                for (int j = 0; j < resourceTypeNodes.getLength(); j++) {
+                    Element resourceTypeElement = (Element) resourceTypeNodes.item(j);
+                    if (resourceTypeElement.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "addressbook").getLength() > 0) {
+                        isAddressbook = true;
+                        break;
+                    }
+                }
+
+                if (isAddressbook) {
+                    String href = responseElement.getElementsByTagNameNS("DAV:", "href").item(0).getTextContent();
+                    String displayName = responseElement.getElementsByTagNameNS("DAV:", "displayname").item(0).getTextContent();
+                    addressbooks.add(new Addressbook(URI.create(href), displayName));
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse addressbooks from response", e);
+        }
+        return addressbooks;
+    }
+
+    private List<String> extractVCards(String xmlResponse) {
+        List<String> vcards = new ArrayList<>();
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new InputSource(new StringReader(xmlResponse)));
+            NodeList vcardNodes = doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "address-data");
+            for (int i = 0; i < vcardNodes.getLength(); i++) {
+                vcards.add(vcardNodes.item(i).getTextContent());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse vCards from response", e);
+        }
+        return vcards;
+    }
+}

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -1,5 +1,6 @@
 package me.bmordue.redweed.service;
 
+import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.client.HttpClient;
@@ -37,7 +38,7 @@ public class CaldavService {
                 </d:propfind>
                 """;
 
-        HttpRequest<?> request = HttpRequest.create("PROPFIND", principalUrl.toString())
+        HttpRequest<?> request = HttpRequest.create(HttpMethod.CUSTOM, principalUrl.toString(), "PROPFIND")
                 .header("Depth", "0")
                 .header("Content-Type", "application/xml")
 .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8)))
@@ -62,7 +63,7 @@ public class CaldavService {
                 </d:propfind>
                 """;
 
-        HttpRequest<?> request = HttpRequest.create("PROPFIND", addressbookHomeSetUrl.toString())
+        HttpRequest<?> request = HttpRequest.create(HttpMethod.CUSTOM, addressbookHomeSetUrl.toString(), "PROPFIND")
                 .header("Depth", "1")
                 .header("Content-Type", "application/xml")
                 .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
@@ -93,7 +94,7 @@ public class CaldavService {
                 </c:addressbook-multiget>
                 """.formatted(hrefElements.toString());
 
-        HttpRequest<?> request = HttpRequest.create("REPORT", addressbookUrl.toString())
+        HttpRequest<?> request = HttpRequest.create(HttpMethod.CUSTOM, addressbookUrl.toString(), "PROPFIND")
                 .header("Content-Type", "application/xml")
                 .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
                 .body(requestBody);

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -41,7 +41,7 @@ public class CaldavService {
         HttpRequest<?> request = HttpRequest.create(HttpMethod.CUSTOM, principalUrl.toString(), "PROPFIND")
                 .header("Depth", "0")
                 .header("Content-Type", "application/xml")
-.header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8)))
+                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8)))
                 .body(requestBody);
 
         HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
@@ -114,6 +114,10 @@ public class CaldavService {
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setNamespaceAware(true);
+
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(xmlResponse)));
             NodeList nodeList = doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "addressbook-home-set");
@@ -123,8 +127,8 @@ public class CaldavService {
                     return element.getChildNodes().item(0).getTextContent();
                 }
             }
-            throw new RuntimeException("Addressbook home set URL not found in response");
-        } catch (Exception e) {
+            throw new IllegalStateException("Addressbook home set URL not found in response");
+        } catch (javax.xml.parsers.ParserConfigurationException | org.xml.sax.SAXException | java.io.IOException e) {
             throw new RuntimeException("Failed to parse addressbook home set URL from response", e);
         }
     }

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -104,6 +104,9 @@ public class CaldavService {
     private String extractAddressbookHomeSetUrl(String xmlResponse) {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(xmlResponse)));
             NodeList nodeList = doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "addressbook-home-set");

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -140,7 +140,10 @@ public class CaldavService {
 
                 if (isAddressbook) {
                     String href = responseElement.getElementsByTagNameNS("DAV:", "href").item(0).getTextContent();
-                    String displayName = responseElement.getElementsByTagNameNS("DAV:", "displayname").item(0).getTextContent();
+                    NodeList displayNameNodes = responseElement.getElementsByTagNameNS("DAV:", "displayname");
+                    String displayName = (displayNameNodes.getLength() > 0 && displayNameNodes.item(0) != null)
+                            ? displayNameNodes.item(0).getTextContent()
+                            : null; // or use a default value like "" if preferred
                     addressbooks.add(new Addressbook(URI.create(href), displayName));
                 }
             }

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -77,15 +77,21 @@ public class CaldavService {
         }
     }
 
-    public List<String> getVCards(URI addressbookUrl, String username, String password) {
+    public List<String> getVCards(URI addressbookUrl, String username, String password, List<String> vCardUrls) {
+        StringBuilder hrefElements = new StringBuilder();
+        for (String vCardUrl : vCardUrls) {
+            hrefElements.append("<d:href>").append(vCardUrl).append("</d:href>");
+        }
+
         String requestBody = """
                 <c:addressbook-multiget xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav">
                   <d:prop>
                     <d:getetag />
                     <c:address-data />
                   </d:prop>
+                  %s
                 </c:addressbook-multiget>
-                """;
+                """.formatted(hrefElements.toString());
 
         HttpRequest<?> request = HttpRequest.create("REPORT", addressbookUrl.toString())
                 .header("Content-Type", "application/xml")

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -40,7 +40,7 @@ public class CaldavService {
         HttpRequest<?> request = HttpRequest.create("PROPFIND", principalUrl.toString())
                 .header("Depth", "0")
                 .header("Content-Type", "application/xml")
-                .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
+.header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8)))
                 .body(requestBody);
 
         HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -106,11 +106,14 @@ public class CaldavService {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(new InputSource(new StringReader(xmlResponse)));
-            return doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "addressbook-home-set")
-                    .item(0)
-                    .getChildNodes()
-                    .item(0)
-                    .getTextContent();
+            NodeList nodeList = doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:carddav", "addressbook-home-set");
+            if (nodeList.getLength() > 0 && nodeList.item(0) != null) {
+                Element element = (Element) nodeList.item(0);
+                if (element.getChildNodes().getLength() > 0 && element.getChildNodes().item(0) != null) {
+                    return element.getChildNodes().item(0).getTextContent();
+                }
+            }
+            throw new RuntimeException("Addressbook home set URL not found in response");
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse addressbook home set URL from response", e);
         }

--- a/jweed/src/main/java/me/bmordue/redweed/service/VCardImportService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/VCardImportService.java
@@ -1,0 +1,28 @@
+package me.bmordue.redweed.service;
+
+import jakarta.inject.Singleton;
+import me.bmordue.redweed.repository.RdfRepository;
+import org.apache.jena.rdf.model.Model;
+
+import java.net.URI;
+import java.util.List;
+
+@Singleton
+public class VCardImportService {
+
+    private final CaldavService caldavService;
+    private final RdfRepository rdfRepository;
+
+    public VCardImportService(CaldavService caldavService, RdfRepository rdfRepository) {
+        this.caldavService = caldavService;
+        this.rdfRepository = rdfRepository;
+    }
+
+    public void importVCards(URI addressbookUrl, String username, String password) {
+        List<String> vcardStrings = caldavService.getVCards(addressbookUrl, username, password);
+        for (String vcardString : vcardStrings) {
+            Model model = VCardToRdfConverter.convert(vcardString);
+            rdfRepository.save(model);
+        }
+    }
+}

--- a/jweed/src/main/java/me/bmordue/redweed/service/VCardImportService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/VCardImportService.java
@@ -21,8 +21,13 @@ public class VCardImportService {
     public void importVCards(URI addressbookUrl, String username, String password) {
         List<String> vcardStrings = caldavService.getVCards(addressbookUrl, username, password);
         for (String vcardString : vcardStrings) {
-            Model model = VCardToRdfConverter.convert(vcardString);
-            rdfRepository.save(model);
+            try {
+                Model model = VCardToRdfConverter.convert(vcardString);
+                rdfRepository.save(model);
+            } catch (Exception e) {
+                System.err.println("Failed to convert vCard: " + vcardString);
+                e.printStackTrace();
+            }
         }
     }
 }

--- a/jweed/src/main/java/me/bmordue/redweed/service/VCardImportService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/VCardImportService.java
@@ -3,6 +3,7 @@ package me.bmordue.redweed.service;
 import jakarta.inject.Singleton;
 import me.bmordue.redweed.repository.RdfRepository;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 
 import java.net.URI;
 import java.util.List;
@@ -19,15 +20,12 @@ public class VCardImportService {
     }
 
     public void importVCards(URI addressbookUrl, String username, String password) {
-        List<String> vcardStrings = caldavService.getVCards(addressbookUrl, username, password);
+        List<String> empty = List.of();
+        List<String> vcardStrings = caldavService.getVCards(addressbookUrl, username, password, empty);
+        Model combinedModel = ModelFactory.createDefaultModel();
         for (String vcardString : vcardStrings) {
-            try {
-                Model model = VCardToRdfConverter.convert(vcardString);
-                rdfRepository.save(model);
-            } catch (Exception e) {
-                System.err.println("Failed to convert vCard: " + vcardString);
-                e.printStackTrace();
-            }
+            combinedModel.add(VCardToRdfConverter.convert(vcardString));
         }
+        rdfRepository.save(combinedModel);
     }
 }


### PR DESCRIPTION
Adds a feature to import vCards from a CalDAV server using user-provided credentials.

The implementation includes:
- A  to handle communication with the CalDAV server, including discovery of the address book home set and fetching vCards.
- A  to orchestrate the import process, converting vCards to RDF using the existing  and storing them in the .
- A  that exposes a  endpoint to trigger the import.