### PR TITLE
feat: Add initial implementation for CalDAV import

### DIFF
--- a/jweed/build.gradle
+++ b/jweed/build.gradle
@@ -12,6 +12,7 @@ group = "me.bmordue"
 repositories {
     mavenCentral()
     maven { url = 'https://jitpack.io' }
+    maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {
@@ -45,6 +46,7 @@ dependencies {
     implementation("io.micronaut.micrometer:micronaut-micrometer-registry-prometheus")
     implementation 'org.bytedeco:javacv-platform:1.5.10'
     implementation 'jaxen:jaxen:2.0.0'
+    implementation 'org.ical4j:ical4j-connector-dav:2.0.0-alpha6'
 }
 
 

--- a/jweed/src/main/java/me/bmordue/redweed/config/CaldavConfiguration.java
+++ b/jweed/src/main/java/me/bmordue/redweed/config/CaldavConfiguration.java
@@ -1,0 +1,35 @@
+package me.bmordue.redweed.config;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+@ConfigurationProperties("caldav")
+public class CaldavConfiguration {
+
+    private String url;
+    private String username;
+    private String password;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/jweed/src/main/java/me/bmordue/redweed/controller/CaldavController.java
+++ b/jweed/src/main/java/me/bmordue/redweed/controller/CaldavController.java
@@ -1,0 +1,46 @@
+package me.bmordue.redweed.controller;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import jakarta.inject.Inject;
+import me.bmordue.redweed.model.dto.CaldavImportResponseDto;
+import me.bmordue.redweed.service.CaldavService;
+import me.bmordue.redweed.service.PersonService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+@Controller("/caldav")
+public class CaldavController {
+
+    private static final Logger log = LoggerFactory.getLogger(CaldavController.class);
+
+    private final CaldavService caldavService;
+    private final PersonService personService;
+
+    @Inject
+    public CaldavController(CaldavService caldavService, PersonService personService) {
+        this.caldavService = caldavService;
+        this.personService = personService;
+    }
+
+    @Post("/import")
+    public HttpResponse<CaldavImportResponseDto> importFromCaldav() {
+        log.info("Starting CalDAV import.");
+        List<String> vcards = caldavService.fetchVCardResources();
+        int importCount = 0;
+        for (String vcard : vcards) {
+            try {
+                personService.ingestVCard(vcard);
+                importCount++;
+            } catch (Exception e) {
+                log.error("Failed to import a vCard, skipping.", e);
+            }
+        }
+        log.info("Finished CalDAV import. Imported {} vCards.", importCount);
+        CaldavImportResponseDto response = new CaldavImportResponseDto("Import complete", importCount);
+        return HttpResponse.ok(response);
+    }
+}

--- a/jweed/src/main/java/me/bmordue/redweed/model/dto/CaldavImportResponseDto.java
+++ b/jweed/src/main/java/me/bmordue/redweed/model/dto/CaldavImportResponseDto.java
@@ -1,0 +1,3 @@
+package me.bmordue.redweed.model.dto;
+
+public record CaldavImportResponseDto(String message, int importedCount) {}

--- a/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
+++ b/jweed/src/main/java/me/bmordue/redweed/service/CaldavService.java
@@ -1,0 +1,46 @@
+package me.bmordue.redweed.service;
+
+import jakarta.inject.Singleton;
+import me.bmordue.redweed.config.CaldavConfiguration;
+import net.fortuna.ical4j.connector.dav.CalDavStore;
+import net.fortuna.ical4j.connector.dav.CardDavStore;
+import net.fortuna.ical4j.connector.dav.property.DavProperty;
+import net.fortuna.ical4j.vcard.VCard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+@Singleton
+public class CaldavService {
+
+    private static final Logger log = LoggerFactory.getLogger(CaldavService.class);
+
+    private final CaldavConfiguration caldavConfiguration;
+
+    public CaldavService(CaldavConfiguration caldavConfiguration) {
+        this.caldavConfiguration = caldavConfiguration;
+    }
+
+    public List<String> fetchVCardResources() {
+        List<String> vcards = new ArrayList<>();
+        try {
+            URL url = new URL(caldavConfiguration.getUrl());
+            CardDavStore store = new CardDavStore(url, caldavConfiguration.getUsername(), caldavConfiguration.getPassword().toCharArray());
+            store.connect();
+            // Assuming the URL is the address book collection URL
+            net.fortuna.ical4j.connector.CardCollection<VCard> cardCollection = store.getCollection(url.getPath());
+
+            for (VCard card : cardCollection.getComponents()) {
+                vcards.add(card.toString());
+            }
+            store.disconnect();
+        } catch (Exception e) {
+            log.error("Failed to fetch vCards from CalDAV server", e);
+            throw new RuntimeException("Failed to fetch vCards from CalDAV server", e);
+        }
+        return vcards;
+    }
+}

--- a/jweed/src/test/java/me/bmordue/redweed/controller/CaldavControllerTest.java
+++ b/jweed/src/test/java/me/bmordue/redweed/controller/CaldavControllerTest.java
@@ -1,0 +1,81 @@
+package me.bmordue.redweed.controller;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.annotation.MockBean;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import me.bmordue.redweed.model.dto.CaldavImportResponseDto;
+import me.bmordue.redweed.service.CaldavService;
+import me.bmordue.redweed.service.PersonService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@MicronautTest
+class CaldavControllerTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Inject
+    CaldavService caldavService;
+
+    @Inject
+    PersonService personService;
+
+    @Test
+    void testImportFromCaldavSuccess() {
+        // Given
+        when(caldavService.fetchVCardResources()).thenReturn(List.of("vcard1", "vcard2"));
+        doNothing().when(personService).ingestVCard(anyString());
+
+        // When
+        HttpRequest<Object> request = HttpRequest.POST("/caldav/import", "");
+        HttpResponse<CaldavImportResponseDto> response = client.toBlocking().exchange(request, CaldavImportResponseDto.class);
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertEquals("Import complete", response.body().message());
+        assertEquals(2, response.body().importedCount());
+
+        verify(caldavService, times(1)).fetchVCardResources();
+        verify(personService, times(2)).ingestVCard(anyString());
+    }
+
+    @Test
+    void testImportFromCaldavServiceThrowsException() {
+        // Given
+        when(caldavService.fetchVCardResources()).thenThrow(new RuntimeException("Test Exception"));
+
+        // When
+        HttpRequest<Object> request = HttpRequest.POST("/caldav/import", "");
+        HttpResponse<CaldavImportResponseDto> response = client.toBlocking().exchange(request, CaldavImportResponseDto.class);
+
+
+        // Then
+        // The controller catches the exception and returns a 0 count.
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertEquals(0, response.body().importedCount());
+
+        verify(caldavService, times(1)).fetchVCardResources();
+        verify(personService, never()).ingestVCard(anyString());
+    }
+
+    @MockBean(CaldavService.class)
+    CaldavService caldavService() {
+        return mock(CaldavService.class);
+    }
+
+    @MockBean(PersonService.class)
+    PersonService personService() {
+        return mock(PersonService.class);
+    }
+}


### PR DESCRIPTION
This commit introduces the basic structure for importing vCards from a CalDAV server. It includes:
- A new CaldavController with a /caldav/import endpoint.
- A CaldavService for handling CalDAV communication.
- A CaldavConfiguration class for credentials.
- A unit test for the controller.

The code is currently not compiling due to issues with the CalDAV client library. The `ical4j-connector-dav` dependency has been added, but the correct usage is still being determined. The CaldavService implementation is a placeholder and needs to be corrected.